### PR TITLE
Fixed Image Display Issues in .adoc Files for Chapters 01-11

### DIFF
--- a/app2-answers.adoc
+++ b/app2-answers.adoc
@@ -1,6 +1,7 @@
 [appendix]
 [[app2]]
 == Answers to exercises
+:baseimagedir: images
 :imagedir: {baseimagedir}/app2
 
 === Chapter 2

--- a/ch01-introduction-to-bitcoin.adoc
+++ b/ch01-introduction-to-bitcoin.adoc
@@ -1,6 +1,6 @@
 [[ch01]]
 == Introduction to Bitcoin
-:baseimagedir: grokkingbitcoin/images
+:baseimagedir: /grokkingbitcoin/images
 :imagedir: {baseimagedir}/ch01
 
 * Getting to know Bitcoin

--- a/ch01-introduction-to-bitcoin.adoc
+++ b/ch01-introduction-to-bitcoin.adoc
@@ -1,6 +1,6 @@
 [[ch01]]
 == Introduction to Bitcoin
-:baseimagedir: /grokkingbitcoin/images
+:baseimagedir: images
 :imagedir: {baseimagedir}/ch01
 
 * Getting to know Bitcoin

--- a/ch01-introduction-to-bitcoin.adoc
+++ b/ch01-introduction-to-bitcoin.adoc
@@ -54,7 +54,7 @@ access and a computer program, like a mobile app, to use it.
 
 .The Bitcoin network and its ecosystem.
 [[actors]]
-image::{imagedir}/01-01.svg[{big-width}]
+image::images/ch01/01-01.svg[{big-width}]
 
 Anyone can use or participate in the Bitcoin network without special
 permission from a bank or similar institution. Thanks to Bitcoin’s

--- a/ch01-introduction-to-bitcoin.adoc
+++ b/ch01-introduction-to-bitcoin.adoc
@@ -1,5 +1,6 @@
 [[ch01]]
 == Introduction to Bitcoin
+:baseimagedir: grokkingbitcoin/images
 :imagedir: {baseimagedir}/ch01
 
 * Getting to know Bitcoin
@@ -210,6 +211,7 @@ this by consulting its local copy of the blockchain and verifying that
 
 [[overview-bitcoin-network]]
 .Alice has sent her transaction to a node in the network. The node verifies the transaction and forwards it to other nodes. Eventually, the transaction will reach all nodes in the network.
+
 image::{imagedir}/01-04.svg[{full-width}]
 
 [.inbitcoin]

--- a/ch02-hash-functions-and-signatures.adoc
+++ b/ch02-hash-functions-and-signatures.adoc
@@ -1,5 +1,6 @@
 [[ch02]]
 == Cryptographic hash functions and digital signatures
+:baseimagedir: images
 :imagedir: {baseimagedir}/ch02
 
 This chapter covers

--- a/ch03-addresses.adoc
+++ b/ch03-addresses.adoc
@@ -1,5 +1,6 @@
 [[ch03]]
 == Addresses
+:baseimagedir: images
 :imagedir: {baseimagedir}/ch03
 
 This chapter covers

--- a/ch04-wallets.adoc
+++ b/ch04-wallets.adoc
@@ -1,5 +1,6 @@
 [[ch04]]
 == Wallets
+:baseimagedir: images
 :imagedir: {baseimagedir}/ch04
 
 This chapter covers

--- a/ch05-transactions.adoc
+++ b/ch05-transactions.adoc
@@ -1,5 +1,6 @@
 [[ch05]]
 == Transactions
+:baseimagedir: images
 :imagedir: {baseimagedir}/ch05
 
 This chapter covers

--- a/ch06-the-blockchain.adoc
+++ b/ch06-the-blockchain.adoc
@@ -1,5 +1,6 @@
 [[ch06]]
 == The blockchain
+:baseimagedir: images
 :imagedir: {baseimagedir}/ch06
 
 This chapter covers

--- a/ch07-proof-of-work.adoc
+++ b/ch07-proof-of-work.adoc
@@ -1,5 +1,6 @@
 [[ch07]]
 == Proof of work
+:baseimagedir: images
 :imagedir: {baseimagedir}/ch07
 This chapter covers
 

--- a/ch08-peer-to-peer-network.adoc
+++ b/ch08-peer-to-peer-network.adoc
@@ -1,5 +1,6 @@
 [[ch08]]
 == Peer-to-peer network
+:baseimagedir: images
 :imagedir: {baseimagedir}/ch08
 This chapter covers
 

--- a/ch09-transactions-revisited.adoc
+++ b/ch09-transactions-revisited.adoc
@@ -1,5 +1,6 @@
 [[ch09]]
 == Transactions revisited
+:baseimagedir: images
 :imagedir: {baseimagedir}/ch09
 
 This chapter covers

--- a/ch10-segregated-witness.adoc
+++ b/ch10-segregated-witness.adoc
@@ -1,5 +1,6 @@
 [[ch10]]
 == Segregated witness
+:baseimagedir: images
 :imagedir: {baseimagedir}/ch10
 
 This chapter covers

--- a/ch11-bitcoin-upgrades.adoc
+++ b/ch11-bitcoin-upgrades.adoc
@@ -1,5 +1,6 @@
 [[ch11]]
 == Bitcoin upgrades
+:baseimagedir: images
 :imagedir: {baseimagedir}/ch11
 
 This chapter covers

--- a/front-matter.adoc
+++ b/front-matter.adoc
@@ -7,6 +7,7 @@ _And to all awesome Bitcoiners everywhere._
 
 [preface]
 == Foreword
+:baseimagedir: images
 :imagedir: {baseimagedir}/fm
 
 What is the difference between Bitcoin and the various monies used in


### PR DESCRIPTION
This pull request fixes the issue where images were not being displayed in the `.adoc` files for chapters 01 through 11. 

### Changes: 
- Updated "baseimagedir" with the correct path.

### Testing
- Checked the output to ensure all images appear as expected in the final documents.

### Additional Notes

- Please review the changes to ensure there are no missing or incorrect image references.
- Let me know if there are any additional adjustments needed.

